### PR TITLE
Remove openapi docs copy in dockefile

### DIFF
--- a/docker/depl.dockerfile
+++ b/docker/depl.dockerfile
@@ -20,8 +20,6 @@ ENV JAR="iudx.auditing.server-cluster-${VERSION}-fat.jar"
 
 WORKDIR /usr/share/app
 
-# Copying openapi docs
-COPY docs docs
 COPY iudx-pmd-ruleset.xml iudx-pmd-ruleset.xml
 COPY google_checks.xml google_checks.xml
 

--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -21,8 +21,6 @@ ENV JAR="iudx.auditing.server-dev-${VERSION}-fat.jar"
 
 WORKDIR /usr/share/app
 
-# Copying openapi docs
-COPY docs docs
 COPY iudx-pmd-ruleset.xml iudx-pmd-ruleset.xml
 COPY google_checks.xml google_checks.xml
 


### PR DESCRIPTION
- because docs folder does not exist for auditing server