### PR TITLE
fix immudbService

### DIFF
--- a/src/main/java/org/cdpg/dx/auditingserver/activity/immudbActivity/impl/ImmudbActivityServiceImpl.java
+++ b/src/main/java/org/cdpg/dx/auditingserver/activity/immudbActivity/impl/ImmudbActivityServiceImpl.java
@@ -26,6 +26,6 @@ public class ImmudbActivityServiceImpl implements ImmudbActivityService {
         "Inserting activity log into immudb with columns: {}, values: {}", columns, values);
     InsertQuery insertQuery =
         new InsertQuery().setTable(DB_TABLE_NAME).setColumns(columns).setValues(values);
-    return immudbService.executeQuery(insertQuery).mapEmpty();
+    return immudbService.executeQuery(insertQuery, activityLogEntity.id()).mapEmpty();
   }
 }

--- a/src/main/java/org/cdpg/dx/database/immudb/service/ImmudbService.java
+++ b/src/main/java/org/cdpg/dx/database/immudb/service/ImmudbService.java
@@ -12,7 +12,7 @@ import org.cdpg.dx.database.immudb.query.InsertQuery;
 @ProxyGen
 public interface ImmudbService {
 
-  Future<Boolean> executeQuery(InsertQuery insertQuery);
+  Future<Boolean> executeQuery(InsertQuery insertQuery, String verificatioFild);
 
   static ImmudbService createProxy(Vertx vertx, String address) {
     return new ImmudbServiceVertxEBProxy(vertx, address);

--- a/src/main/java/org/cdpg/dx/database/immudb/service/ImmudbServiceImpl.java
+++ b/src/main/java/org/cdpg/dx/database/immudb/service/ImmudbServiceImpl.java
@@ -6,6 +6,8 @@ import io.vertx.core.Vertx;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.cdpg.dx.database.immudb.query.InsertQuery;
@@ -13,6 +15,8 @@ import org.cdpg.dx.database.immudb.query.InsertQuery;
 public class ImmudbServiceImpl implements ImmudbService {
   private static final Logger LOGGER = LogManager.getLogger(ImmudbServiceImpl.class);
   private static final int MAX_RETRIES = 2;
+  private static final int VERIFICATION_TIMEOUT_MS = 2000;
+
   private final Vertx vertx;
   private final PgConnectOptions connectOptions;
   private final PoolOptions poolOptions;
@@ -27,13 +31,14 @@ public class ImmudbServiceImpl implements ImmudbService {
   }
 
   @Override
-  public Future<Boolean> executeQuery(InsertQuery insertQuery) {
+  public Future<Boolean> executeQuery(InsertQuery insertQuery, String verificationFild) {
     Promise<Boolean> promise = Promise.promise();
-    attemptQuery(insertQuery, promise, MAX_RETRIES);
+    attemptQuery(insertQuery, verificationFild, promise, MAX_RETRIES);
     return promise.future();
   }
 
-  private void attemptQuery(InsertQuery insertQuery, Promise<Boolean> promise, int retriesLeft) {
+  private void attemptQuery(
+      InsertQuery insertQuery, String verificationFild, Promise<Boolean> promise, int retriesLeft) {
     LOGGER.debug("Executing Immudb Insert Query: {}", insertQuery.toSQL());
 
     pool.query(insertQuery.toSQL())
@@ -45,23 +50,124 @@ public class ImmudbServiceImpl implements ImmudbService {
                 promise.complete(true);
               } else {
                 LOGGER.error("Insert failed: {}", rows.cause().getMessage());
-                if (retriesLeft > 0) {
-                  LOGGER.info("Retrying... attempts left: {}", retriesLeft);
-                  attemptQuery(insertQuery, promise, retriesLeft - 1);
+                verifyInsertWithTimeout(insertQuery, verificationFild)
+                    .onComplete(
+                        verifyResult -> {
+                          if (verifyResult.succeeded() && verifyResult.result()) {
+                            LOGGER.info(
+                                "Insert verification succeeded - data was actually inserted");
+                            promise.complete(true);
+                          } else {
+                            LOGGER.warn("Insert verification failed or timed out");
+                            handleRetryOrPoolReset(
+                                insertQuery, verificationFild, promise, retriesLeft);
+                          }
+                        });
+              }
+            });
+  }
+
+  private Future<Boolean> verifyInsertWithTimeout(
+      InsertQuery insertQuery, String verificationFild) {
+    Promise<Boolean> promise = Promise.promise();
+
+    // Set up a timeout
+    long timerId =
+        vertx.setTimer(
+            VERIFICATION_TIMEOUT_MS,
+            id -> {
+              if (!promise.future().isComplete()) {
+                LOGGER.warn("Verification timed out after {} ms", VERIFICATION_TIMEOUT_MS);
+                promise.tryFail("Verification timed out");
+              }
+            });
+
+    verifyInsert(insertQuery, verificationFild)
+        .onComplete(
+            result -> {
+              vertx.cancelTimer(timerId);
+              if (!promise.future().isComplete()) {
+                if (result.succeeded()) {
+                  promise.tryComplete(result.result());
                 } else {
-                  LOGGER.warn("All retry attempts exhausted. Closing and recreating pool...");
-                  resetPool()
+                  promise.tryFail(result.cause());
+                }
+              }
+            });
+
+    return promise.future();
+  }
+
+  private Future<Boolean> verifyInsert(InsertQuery insertQuery, String verificationFild) {
+    Promise<Boolean> promise = Promise.promise();
+
+    try {
+      String verificationQuery = buildVerificationQuery(insertQuery.getTable(), verificationFild);
+      if (verificationQuery == null) {
+        LOGGER.warn("Cannot verify insert - no verification query could be built");
+        promise.complete(false);
+        return promise.future();
+      }
+
+      LOGGER.debug("Executing verification query: {}", verificationQuery);
+      pool.query(verificationQuery)
+          .execute()
+          .onComplete(
+              result -> {
+                if (result.succeeded()) {
+                  boolean exists = checkIfDataExists(result.result());
+                  LOGGER.debug("Verification result: {}", exists);
+                  promise.complete(exists);
+                } else {
+                  LOGGER.warn("Verification query failed: {}", result.cause().getMessage());
+                  promise.complete(false);
+                }
+              });
+    } catch (Exception e) {
+      LOGGER.error("Error during verification: {}", e.getMessage());
+      promise.complete(false);
+    }
+
+    return promise.future();
+  }
+
+  private String buildVerificationQuery(String tableName, String verificatioFild) {
+
+    String query = "SELECT * FROM " + tableName + " WHERE id = '" + verificatioFild + "'";
+    LOGGER.info("Building verification query for table: {}, field: {}", tableName, verificatioFild);
+    LOGGER.info("Verification query: {}", query);
+    return query;
+  }
+
+  private boolean checkIfDataExists(RowSet<Row> result) {
+    return result != null && result.iterator().hasNext();
+  }
+
+  private void handleRetryOrPoolReset(
+      InsertQuery insertQuery, String verificatioFild, Promise<Boolean> promise, int retriesLeft) {
+    if (retriesLeft > 0) {
+      LOGGER.info("Retrying... attempts left: {}", retriesLeft);
+      vertx.setTimer(
+          1000, id -> attemptQuery(insertQuery, verificatioFild, promise, retriesLeft - 1));
+    } else {
+      LOGGER.warn("All retry attempts exhausted. Closing and recreating pool...");
+      resetPool()
+          .onComplete(
+              ar -> {
+                if (ar.succeeded()) {
+                  LOGGER.info("Pool reset successfully. Trying final attempt...");
+                  pool.query(insertQuery.toSQL())
+                      .execute()
                       .onComplete(
-                          ar -> {
-                            if (ar.succeeded()) {
-                              LOGGER.info("Pool reset successfully. Trying final attempt...");
-                              pool.query(insertQuery.toSQL())
-                                  .execute()
+                          finalTry -> {
+                            if (finalTry.succeeded()) {
+                              LOGGER.info("Immudb Table updated successfully after pool reset.");
+                              promise.complete(true);
+                            } else {
+                              verifyInsertWithTimeout(insertQuery, verificatioFild)
                                   .onComplete(
-                                      finalTry -> {
-                                        if (finalTry.succeeded()) {
-                                          LOGGER.info(
-                                              "Immudb Table updated successfully after pool reset.");
+                                      lastVerify -> {
+                                        if (lastVerify.succeeded() && lastVerify.result()) {
                                           promise.complete(true);
                                         } else {
                                           LOGGER.error(
@@ -70,15 +176,14 @@ public class ImmudbServiceImpl implements ImmudbService {
                                           promise.fail(finalTry.cause());
                                         }
                                       });
-                            } else {
-                              LOGGER.error(
-                                  "Failed to reset connection pool: {}", ar.cause().getMessage());
-                              promise.fail(ar.cause());
                             }
                           });
+                } else {
+                  LOGGER.error("Failed to reset connection pool: {}", ar.cause().getMessage());
+                  promise.fail(ar.cause());
                 }
-              }
-            });
+              });
+    }
   }
 
   private Future<Void> resetPool() {

--- a/src/main/java/org/cdpg/dx/databroker/listeners/ImmudbConsumer.java
+++ b/src/main/java/org/cdpg/dx/databroker/listeners/ImmudbConsumer.java
@@ -5,14 +5,10 @@ import io.vertx.rabbitmq.QueueOptions;
 import io.vertx.rabbitmq.RabbitMQClient;
 import io.vertx.rabbitmq.RabbitMQConsumer;
 import io.vertx.rabbitmq.RabbitMQMessage;
-import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.cdpg.dx.auditingserver.activity.immudbActivity.ImmudbActivityService;
-import org.cdpg.dx.auditingserver.activity.model.ActivityLog;
 import org.cdpg.dx.auditingserver.activity.model.ImmudbActivityLog;
-import org.cdpg.dx.auditingserver.activity.service.ActivityService;
-import org.cdpg.dx.database.immudb.service.ImmudbService;
 
 public class ImmudbConsumer implements RabitMqConsumer {
 
@@ -70,7 +66,8 @@ public class ImmudbConsumer implements RabitMqConsumer {
       ackMessage(deliveryTag);
     }
 
-    activityService.insertActivityLogIntoImmudb(immudbActivityLog)
+    activityService
+        .insertActivityLogIntoImmudb(immudbActivityLog)
         .onSuccess(
             v -> {
               LOGGER.info("Activity log inserted into Immudb successfully.");
@@ -80,9 +77,7 @@ public class ImmudbConsumer implements RabitMqConsumer {
             err -> {
               LOGGER.error("Error inserting activity log into Immudb: {}", err.getMessage());
             });
-
   }
-
 
   private void ackMessage(long deliveryTag) {
     rabbitMqClient.basicAck(deliveryTag, false);


### PR DESCRIPTION
fix: verify Immudb insertion on failure and ack message if data exists

- On failure to insert activity log into Immudb, added logic to check if the data was actually inserted.
- If the data is found in Immudb, treat as success and acknowledge the message in RabbitMQ.
- Ensures messages are not reprocessed if insertion succeeded but exception was thrown.
- Optimized error handling and logging.